### PR TITLE
Avoid 3rd party helper naming collision

### DIFF
--- a/addon/templates/components/button-spinner.hbs
+++ b/addon/templates/components/button-spinner.hbs
@@ -12,6 +12,9 @@
         </div>
     {{else}}
         {{#if hasIcon}}
+            {{!-- we need to explicity reference this.propName here --}}
+            {{!-- to avoid a naming collision with a 3rd party addon --}}
+            {{!-- that has a helper named "icon" --}}
             {{fa-icon this.icon class="action-button-icon"}}
         {{/if}}
         {{#if (not iconBtn)}}

--- a/addon/templates/components/button-spinner.hbs
+++ b/addon/templates/components/button-spinner.hbs
@@ -12,7 +12,7 @@
         </div>
     {{else}}
         {{#if hasIcon}}
-            {{fa-icon icon class="action-button-icon"}}
+            {{fa-icon this.icon class="action-button-icon"}}
         {{/if}}
         {{#if (not iconBtn)}}
             {{#if label}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gavant-ember-button-spinner",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -23,7 +23,7 @@
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-font-awesome": "4.0.0-rc.3",
-    "gavant-ember-button-basic": "^0.0.7"
+    "gavant-ember-button-basic": "^0.0.8"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",


### PR DESCRIPTION
Workaround for issue caused by ember-leaftlet's inclusion of a helper called icon, which collides with the icon component property, as global helper's take precendence over property names in the ember resolver.

see: miguelcobain/ember-leaflet#175